### PR TITLE
開発コンテナーにgcloudを設定する

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,16 +3,20 @@
 {
 	"name": "Ruby",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/ruby:1-3.3-bullseye"
+	"image": "mcr.microsoft.com/devcontainers/ruby:1-3.3-bullseye",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
+	// "features": {
+		// "ghcr.io/devcontainers/features/google-cloud-cli:1": {}
+	// },
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "ruby --version",
+	// "postCreateCommand": "curl -sSL https://sdk.cloud.google.com > /tmp/install.sh && bash /tmp/install.sh --disable-prompts"
+	// "postCreateCommand": "curl -sSL https://sdk.cloud.google.com > ./install.sh && bash ./install.sh --disable-prompts && rm ./install.sh"
+	"postCreateCommand": "curl -sSL https://sdk.cloud.google.com | bash"
 
 	// Configure tool-specific properties.
 	// "customizations": {},

--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ crawl the financial(motrgage rate) sites
 https://console.cloud.google.com/welcome?hl=ja&inv=1&invt=AbwiGQ&project=mortgage-458822
 
 
+## Dev Container
+
+- gcloudの質問プロンプトが出てきますが、すべてデフォルト（ENTERを押す）で進めてください。
+


### PR DESCRIPTION
Fixes #2

## Sourceryによるサマリー

開発コンテナ内でGoogle Cloud SDK (gcloud) を構成します。

ドキュメント:
- 開発コンテナ内でgcloudをセットアップする手順を追加しました。

雑務:
- READMEを更新し、開発コンテナの構成に関するガイダンスを記載しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Configure Google Cloud SDK (gcloud) in the development container

Documentation:
- Added instructions for setting up gcloud in the development container

Chores:
- Updated README with dev container configuration guidance

</details>