### PR TITLE
Cloud RunでPlaywrightスクリプトを実行

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 .vscode
 .idea
 .readmes
+deploy-command.txt

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ build-iPhoneSimulator/
 # Used by RuboCop. Remote config files pulled in from inherit_from directive.
 # .rubocop-https?--*
 .env
+client_secret.json
+deploy-cmd.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY requirements.txt .
 RUN pip install --trusted-host pypi.python.org -r requirements.txt
 
 # Playwrightのブラウザバイナリをインストール
-# RUN playwright install --with-deps
+RUN playwright install --with-deps
 
 # Copy the rest of the working directory contents into the container at /app
 COPY . .

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # financial_crawler
 
-crawl the financial(motrgage rate) sites
+crawl the financial(mortgage rate) sites
 
 ## Google Cloud Console
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,25 @@
 # financial_crawler
+
 crawl the financial(motrgage rate) sites
 
 ## Google Cloud Console
 
 - https://console.cloud.google.com/welcome
 
-GET URL
+## Cloud Run
+
+### Deploy
+
+- https://cloud.google.com/code/docs/vscode/deploy-service?hl=ja
+
+- Command
+
+```bash
+gcloud run deploy financial-crawler --project PROJECTID --image gcr.io/PROJECTID/financial-crawler --client-name "Cloud Code for VS Code" --client-version 2.31.1 --platform managed --region asia-northeast1 --allow-unauthenticated --port 8080 --cpu 1 --memory 512Mi --concurrency 80 --timeout 300 --clear-env-vars
+```
+
+## GET URL
+
 ```
 gcloud run services describe ruby-http-function --region=asia-northeast1  --format=json
 ```

--- a/app.py
+++ b/app.py
@@ -3,13 +3,27 @@ A sample Hello World server.
 """
 import os
 from playwright.sync_api import sync_playwright
-from flask import Flask, jsonify
+from flask import Flask, jsonify, render_template
 
 # pylint: disable=C0103
 app = Flask(__name__)
 
 
 @app.route('/')
+def hello():
+    """Return a friendly HTTP greeting."""
+    message = "It's running!, marzg!"
+
+    """Get Cloud Run environment variables."""
+    service = os.environ.get('K_SERVICE', 'Unknown service')
+    revision = os.environ.get('K_REVISION', 'Unknown revision')
+
+    return render_template('index.html',
+        message=message,
+        Service=service,
+        Revision=revision)
+
+@app.route('/exec', methods=['GET'])
 def exec_playwright():
   # playwrightの実装  
   try:    

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,6 +7,8 @@
 <link href="https://fonts.googleapis.com/css?family=Roboto" rel="preload" as="font">
 <link href="/static/cloud-run-32-color.png" rel="icon" type="image/png" />
 <link href="/static/style.css" rel="stylesheet" type="text/css" />
+<script src="https://apis.google.com/js/platform.js" async defer></script>
+<meta name="google-signin-client_id" content="188456058762-m1to002quta5j0r5ctsvqb9rmui1kph5.apps.googleusercontent.com">
 </head>
 
 <body>
@@ -23,6 +25,25 @@
 				<h1>{{message}}</h1>
 				<h2>Congratulations, you successfully deployed a container image to Cloud Run</h2>
 			</div>
+			<div class="g-signin2" data-onsuccess="onSignIn"></div>
+			<script>
+				function onSignIn(googleUser) {
+					var profile = googleUser.getBasicProfile();
+					console.log('ID: ' + profile.getId()); // Do not send to your backend! Use an ID token instead.
+					console.log('Name: ' + profile.getName());
+					console.log('Image URL: ' + profile.getImageUrl());
+					console.log('Email: ' + profile.getEmail()); // This is null if the 'email' scope is not present.
+				}
+			</script>
+			<a href="#" onclick="signOut();">Sign out</a>
+			<script>
+				function signOut() {
+					var auth2 = gapi.auth2.getAuthInstance();
+					auth2.signOut().then(function () {
+						console.log('User signed out.');
+					});
+				}
+			</script>
 		</div>
 
 		<div class="details">

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,8 +7,6 @@
 <link href="https://fonts.googleapis.com/css?family=Roboto" rel="preload" as="font">
 <link href="/static/cloud-run-32-color.png" rel="icon" type="image/png" />
 <link href="/static/style.css" rel="stylesheet" type="text/css" />
-<script src="https://apis.google.com/js/platform.js" async defer></script>
-<meta name="google-signin-client_id" content="188456058762-m1to002quta5j0r5ctsvqb9rmui1kph5.apps.googleusercontent.com">
 </head>
 
 <body>
@@ -25,25 +23,6 @@
 				<h1>{{message}}</h1>
 				<h2>Congratulations, you successfully deployed a container image to Cloud Run</h2>
 			</div>
-			<div class="g-signin2" data-onsuccess="onSignIn"></div>
-			<script>
-				function onSignIn(googleUser) {
-					var profile = googleUser.getBasicProfile();
-					console.log('ID: ' + profile.getId()); // Do not send to your backend! Use an ID token instead.
-					console.log('Name: ' + profile.getName());
-					console.log('Image URL: ' + profile.getImageUrl());
-					console.log('Email: ' + profile.getEmail()); // This is null if the 'email' scope is not present.
-				}
-			</script>
-			<a href="#" onclick="signOut();">Sign out</a>
-			<script>
-				function signOut() {
-					var auth2 = gapi.auth2.getAuthInstance();
-					auth2.signOut().then(function () {
-						console.log('User signed out.');
-					});
-				}
-			</script>
 		</div>
 
 		<div class="details">


### PR DESCRIPTION
Fixes #17

## Sourceryによるサマリー

Google認証とサービスメタデータを含む新しいHTMLランディングページを提供し、Playwrightの依存関係がDockerにインストールされていることを確認し、Cloud Runのデプロイメントの詳細をREADMEに記述します。

新機能：
- `/`にHTMLベースのランディングページを提供し、挨拶とCloud Runサービスメタデータを表示します。
- テンプレートにサインインおよびサインアウトハンドラーとGoogle Sign-Inを統合します。

機能拡張：
- Dockerイメージのビルド中にPlaywrightブラウザのバイナリをインストールします。

ドキュメンテーション：
- Cloud Runのデプロイ手順とサービスURLの取得方法をREADMEに追加します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Serve a new HTML landing page with Google authentication and service metadata, ensure Playwright dependencies are installed in Docker, and document Cloud Run deployment details in the README.

New Features:
- Serve an HTML-based landing page at `/` that displays a greeting and Cloud Run service metadata
- Integrate Google Sign-In with sign-in and sign-out handlers in the template

Enhancements:
- Install Playwright browser binaries during Docker image build

Documentation:
- Add Cloud Run deployment instructions and service URL retrieval to the README

</details>