### PR TITLE
Yahooのトップページから特定のリンクへ飛ぶ

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,7 +23,12 @@
         "minikube": {}
       },
       "watch": true,
-      "externalPortForward": 3000
+      "externalPortForward": 3000,
+      "debug": {
+        "sourceFileMap": {
+          "${workspaceFolder}": "/app"
+        }
+      }
     }
   ]
 }

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 """
 A sample Hello World server.
 """
+import logging
 import os
 from playwright.sync_api import sync_playwright
 from flask import Flask, jsonify, render_template
@@ -34,6 +35,7 @@ def exec_playwright():
 
             # 新しいページを作成する
             page = browser.new_page()
+            logging.info('page: %s', page)
             print('page: ', page)
 
             # page.goto() で Yahoo のサイトにアクセス
@@ -44,6 +46,7 @@ def exec_playwright():
 
             # yahoo shopping のページに遷移
             page.locator("#Masthead").get_by_role("link", name="ショッピングへ遷移する").click()
+            page.wait_for_load_state()  # ページ遷移後のロード完了を待機
             title_shopping = page.title()
 
             # Browser を閉じる


### PR DESCRIPTION
Fixes #11

## Sourceryによるサマリー

非ASCII JSON出力を有効にし、Playwrightベースの/execエンドポイントを強化して、Yahoo! JAPANのトップページとショッピングページのタイトルを取得して返すようにしました。

新機能：
- /execエンドポイントを拡張し、Yahoo! JAPANのトップページからショッピングリンクに移動して、両方のページのタイトルを返すようにしました。

機能拡張：
- JSON出力でASCIIエスケープを無効にし、日本語文字を保持するようにしました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable non-ASCII JSON output and enhance the Playwright-based /exec endpoint to fetch and return titles for both Yahoo Japan’s top page and its Shopping page.

New Features:
- Extend the /exec endpoint to navigate from Yahoo Japan's top page to the Shopping link and return both page titles.

Enhancements:
- Disable ASCII escaping in JSON output to preserve Japanese characters.

</details>