### PR TITLE
Marzg510/36-ジョブとして実行する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,10 @@ COPY requirements.txt .
 RUN pip install --trusted-host pypi.python.org -r requirements.txt
 
 # Playwrightのブラウザバイナリをインストール
-RUN playwright install --with-deps
+# RUN playwright install --with-deps
 
 # Copy the rest of the working directory contents into the container at /app
 COPY . .
 
 # Run app.py when the container launches
-ENTRYPOINT ["python", "app.py"]
+# ENTRYPOINT ["python", "app.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@ WORKDIR /app
 COPY requirements.txt .
 
 # Install any needed packages specified in requirements.txt
-RUN pip install --trusted-host pypi.python.org -r requirements.txt
+RUN pip install -r requirements.txt --root-user-action=ignore
 
 # Playwrightのブラウザバイナリをインストール
-# RUN playwright install --with-deps
+RUN playwright install --with-deps
 
 # Copy the rest of the working directory contents into the container at /app
 COPY . .

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python3 -m ptvsd --port 3000 --host 0.0.0.0 app.py
+web: python3 main_sample.py

--- a/jobs/Procfile
+++ b/jobs/Procfile
@@ -1,0 +1,1 @@
+web: python3 main.py

--- a/jobs/main.py
+++ b/jobs/main.py
@@ -1,0 +1,62 @@
+import json
+import os
+import random
+import sys
+import time
+
+# Retrieve Job-defined env vars
+TASK_INDEX = os.getenv("CLOUD_RUN_TASK_INDEX", 0)
+TASK_ATTEMPT = os.getenv("CLOUD_RUN_TASK_ATTEMPT", 0)
+# Retrieve User-defined env vars
+SLEEP_MS = os.getenv("SLEEP_MS", 0)
+FAIL_RATE = os.getenv("FAIL_RATE", 0)
+
+
+# Define main script
+def main(sleep_ms=0, fail_rate=0):
+    """Program that simulates work using the sleep method and random failures.
+
+    Args:
+        sleep_ms: number of milliseconds to sleep
+        fail_rate: rate of simulated errors
+    """
+    print(f"Starting Task #{TASK_INDEX}, Attempt #{TASK_ATTEMPT}...")
+    # Simulate work by waiting for a specific amount of time
+    time.sleep(float(sleep_ms) / 1000)  # Convert to seconds
+
+    # Simulate errors
+    random_failure(float(fail_rate))
+
+    print(f"Completed Task #{TASK_INDEX}.")
+
+
+def random_failure(rate):
+    """Throws an error based on fail rate
+
+    Args:
+        rate: a float between 0 and 1
+    """
+    if rate < 0 or rate > 1:
+        # Return without retrying the Job Task
+        print(
+            f"Invalid FAIL_RATE env var value: {rate}. "
+            + "Must be a float between 0 and 1 inclusive."
+        )
+        return
+
+    random_failure = random.random()
+    if random_failure < rate:
+        raise Exception("Task failed.")
+
+
+# Start script
+if __name__ == "__main__":
+    try:
+        main(SLEEP_MS, FAIL_RATE)
+    except Exception as err:
+        message = (
+            f"Task #{TASK_INDEX}, " + f"Attempt #{TASK_ATTEMPT} failed: {str(err)}"
+        )
+
+        print(json.dumps({"message": message, "severity": "ERROR"}))
+        sys.exit(1)  # Retry Job Task by exiting the process

--- a/main_sample.py
+++ b/main_sample.py
@@ -1,0 +1,62 @@
+import json
+import os
+import random
+import sys
+import time
+
+# Retrieve Job-defined env vars
+TASK_INDEX = os.getenv("CLOUD_RUN_TASK_INDEX", 0)
+TASK_ATTEMPT = os.getenv("CLOUD_RUN_TASK_ATTEMPT", 0)
+# Retrieve User-defined env vars
+SLEEP_MS = os.getenv("SLEEP_MS", 0)
+FAIL_RATE = os.getenv("FAIL_RATE", 0)
+
+
+# Define main script
+def main(sleep_ms=0, fail_rate=0):
+    """Program that simulates work using the sleep method and random failures.
+
+    Args:
+        sleep_ms: number of milliseconds to sleep
+        fail_rate: rate of simulated errors
+    """
+    print(f"Starting Task #{TASK_INDEX}, Attempt #{TASK_ATTEMPT}...")
+    # Simulate work by waiting for a specific amount of time
+    time.sleep(float(sleep_ms) / 1000)  # Convert to seconds
+
+    # Simulate errors
+    random_failure(float(fail_rate))
+
+    print(f"Completed Task #{TASK_INDEX}.")
+
+
+def random_failure(rate):
+    """Throws an error based on fail rate
+
+    Args:
+        rate: a float between 0 and 1
+    """
+    if rate < 0 or rate > 1:
+        # Return without retrying the Job Task
+        print(
+            f"Invalid FAIL_RATE env var value: {rate}. "
+            + "Must be a float between 0 and 1 inclusive."
+        )
+        return
+
+    random_failure = random.random()
+    if random_failure < rate:
+        raise Exception("Task failed.")
+
+
+# Start script
+if __name__ == "__main__":
+    try:
+        main(SLEEP_MS, FAIL_RATE)
+    except Exception as err:
+        message = (
+            f"Task #{TASK_INDEX}, " + f"Attempt #{TASK_ATTEMPT} failed: {str(err)}"
+        )
+
+        print(json.dumps({"message": message, "severity": "ERROR"}))
+        sys.exit(1)  # Retry Job Task by exiting the process

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # Flask==2.3.3
 #requests==2.31.0
 # debugpy # Required for debugging.
-# playwright==1.52.0
+playwright==1.52.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.3.3
-requests==2.31.0
-debugpy # Required for debugging.
-playwright==1.52.0
+# Flask==2.3.3
+#requests==2.31.0
+# debugpy # Required for debugging.
+# playwright==1.52.0

--- a/yahoo_sample.py
+++ b/yahoo_sample.py
@@ -1,0 +1,86 @@
+"""
+A sample Yahoo Crawler.
+"""
+import logging
+import os
+from playwright.sync_api import sync_playwright
+import json
+import random
+import sys
+import time
+
+# Retrieve Job-defined env vars
+TASK_INDEX = os.getenv("CLOUD_RUN_TASK_INDEX", 0)
+TASK_ATTEMPT = os.getenv("CLOUD_RUN_TASK_ATTEMPT", 0)
+# Retrieve User-defined env vars
+SLEEP_MS = os.getenv("SLEEP_MS", 3000)
+FAIL_RATE = os.getenv("FAIL_RATE", 0)
+
+# Define main script
+def main(sleep_ms=3000):
+    """Program that simulates work using the sleep method and random failures.
+
+    Args:
+        sleep_ms: number of milliseconds to sleep
+    """
+    print(f"Starting Yahoo Crawling Task #{TASK_INDEX}, Attempt #{TASK_ATTEMPT}...")
+
+    exec_playwright(sleep_ms)
+
+    print(f"Completed Task #{TASK_INDEX}.")
+
+def exec_playwright(sleep_ms):
+    # playwrightの実装
+    try:
+        with sync_playwright() as p:
+            # Chromium (Web Browser)のインスタンスを作成する
+            browser = p.chromium.launch(headless=True)
+
+            # 新しいページを作成する
+            page = browser.new_page()
+            logging.info('page: %s', page)
+
+            # page.goto() で Yahoo のサイトにアクセス
+            print('Going to top page...')
+            page.goto('https://www.yahoo.co.jp/')
+
+            # title tag の値（ページタイトル）を取得し辞書に格納
+            title_top = page.title()
+            print('top page title: ', title_top)
+
+            # 遷移前に待つ
+            time.sleep(float(sleep_ms) / 1000)  # Convert to seconds
+
+            # yahoo shopping のページに遷移
+            print('Going to shopping page...')
+            page.locator("#Masthead").get_by_role("link", name="ショッピングへ遷移する").click()
+            page.wait_for_load_state()  # ページ遷移後のロード完了を待機
+            title_shopping = page.title()
+            print('shopping page title: ', title_shopping)
+
+            # Browser を閉じる
+            browser.close()
+
+        return {
+            'top':{
+                'title': title_top
+            },
+            'shopping':{
+                'title': title_shopping
+            }
+        }, 200
+    except Exception as e:
+        print(f'Exception occured! : {e}')
+        return {'message': str(e)}, 500
+
+# Start script
+if __name__ == "__main__":
+    try:
+        main(SLEEP_MS)
+    except Exception as err:
+        message = (
+            f"Task #{TASK_INDEX}, " + f"Attempt #{TASK_ATTEMPT} failed: {str(err)}"
+        )
+
+        print(json.dumps({"message": message, "severity": "ERROR"}))
+        sys.exit(1)  # Retry Job Task by exiting the process


### PR DESCRIPTION
Fixes #36

## Sourceryによる概要

Flaskウェブサービスからジョブベースの実行モデルに切り替えるため、汎用ジョブランナーとYahooクローラースクリプトを導入し、依存関係をPlaywrightに更新し、DockerfileとProcfileの設定を調整します。

新機能：
- スリープと失敗シミュレーションを行うジョブ実行スクリプトを追加（jobs/main.pyとmain_sample.py）
- PlaywrightベースのYahooクローラーサンプルスクリプトを追加（yahoo_sample.py）
- ジョブとサンプルスクリプトを実行するためのProcfileエントリを導入

機能拡張：
- requirements.txtでFlaskとrequestsの依存関係をコメントアウトし、Playwrightに切り替え
- デフォルトのWebエントリポイントを廃止して、ジョブ中心のアーキテクチャを採用

ビルド：
- pip installで`--root-user-action=ignore`を使用するようにDockerfileを更新
- Dockerfileでデフォルトの`ENTRYPOINT`をコメントアウト

デプロイメント：
- main_sample.pyを起動するようにルートProcfileを更新
- ジョブランナーを起動するためにjobs/Procfileを追加

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch from a Flask web service to a job-based execution model by introducing generic job runner and Yahoo crawler scripts, updating dependencies to Playwright, and adjusting Dockerfile and Procfile configurations.

New Features:
- Add job execution scripts with sleep and failure simulation (jobs/main.py and main_sample.py)
- Add Playwright-based Yahoo crawler sample script (yahoo_sample.py)
- Introduce Procfile entries for running job and sample scripts

Enhancements:
- Comment out Flask and requests dependencies in requirements.txt and switch to Playwright
- Adopt job-centric architecture by deprecating the default web entrypoint

Build:
- Update Dockerfile to use --root-user-action=ignore for pip install
- Comment out default ENTRYPOINT in Dockerfile

Deployment:
- Update root Procfile to launch main_sample.py
- Add jobs/Procfile to launch the job runner

</details>